### PR TITLE
[TECHNICAL SUPPORT] LPS-27219

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandlerImpl.java
@@ -1419,6 +1419,7 @@ public class JournalPortletDataHandlerImpl extends BasePortletDataHandler {
 			int endPos5 = content.indexOf(CharPool.LESS_THAN, beginPos);
 			int endPos6 = content.indexOf(CharPool.QUOTE, beginPos);
 			int endPos7 = content.indexOf(CharPool.SPACE, beginPos);
+			int endPos8 = content.indexOf(CharPool.QUESTION, beginPos);
 
 			int endPos = endPos1;
 
@@ -1444,6 +1445,10 @@ public class JournalPortletDataHandlerImpl extends BasePortletDataHandler {
 
 			if ((endPos == -1) || ((endPos7 != -1) && (endPos7 < endPos))) {
 				endPos = endPos7;
+			}
+
+			if ((endPos == -1) || ((endPos8 != -1) && (endPos8 < endPos))) {
+				endPos = endPos8;
 			}
 
 			if ((beginPos == -1) || (endPos == -1)) {


### PR DESCRIPTION
Hi Zsolt,

If a flash content is embedded in an article and some URL parameters are specified for the flash movie itself in the embedded code, during the export/import process the parameters will be removed so there's no way to keep them during export/import or staging.

The cause of this, that for the replacement for the path of the exported SWF file the ? mark is not considered as the end of the URL that should be replaced.

I fixed it by checking the endPos for '?'

Regards,
Vilmos
