### PR TITLE
[TECH SUPPORT] LPS-27239

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -169,6 +170,22 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		}
 		else {
 			return true;
+		}
+	}
+
+	public Map<Locale, String> getTitleMap() {
+		Locale defaultLocale = LocaleThreadLocal.getDefaultLocale();
+
+		try {
+			Locale articleDefaultLocale = LocaleUtil.fromLanguageId(
+				getDefaultLocale());
+
+			LocaleThreadLocal.setDefaultLocale(articleDefaultLocale);
+
+			return super.getTitleMap();
+		}
+		finally {
+			LocaleThreadLocal.setDefaultLocale(defaultLocale);
 		}
 	}
 


### PR DESCRIPTION
Hi Zsolt,

@KocsisDaniel asked me to send this to you since he's too caught up with escalations this week.

Anyway... so, the main problem here is that the getTitleMap method uses the system default language instead of the article default one. This is especially bad if the title is not localized (non-XML).

The first approach was to add a defaultLanguageId parameter to LocalizationImpl#getLocalization but this would've required us to change the API. After discussing it with Dániel we agreed that a LocaleThreadLocal approach would be the better option.

While testing it I have discovered another bug though (LPS-27751) but I will send a separate pull regarding that.

Thanks already!
Daniel
