### PR TITLE
[TECHNICAL SUPPORT] LPS-26920

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -430,7 +430,8 @@ public class JournalArticleLocalServiceImpl
 					versionedArticle.setStatus(
 						WorkflowConstants.STATUS_EXPIRED);
 
-					versionedArticle.setExpirationDate(now);
+					versionedArticle.setExpirationDate(
+						article.getExpirationDate());
 
 					journalArticlePersistence.update(versionedArticle, false);
 				}


### PR DESCRIPTION
Hi Zsolt,

As we discussed this issue fixes the journal.article.expire.all.versions=true has no effect when auto expire triggered problem. I refactored the checkArticles() method to as the query from the 1st index wasn't suitable for this situation. 

Regards,
Vilmos
