### PR TITLE
[TECHNICAL SUPPORT] LPS-28195 Fixing Backward navigation in Search port let's result list

### DIFF
--- a/portal-web/docroot/html/portlet/search/search.jsp
+++ b/portal-web/docroot/html/portlet/search/search.jsp
@@ -32,6 +32,8 @@ else {
 	primarySearch = portalPreferences.getValue(PortletKeys.SEARCH, "primary-search", StringPool.BLANK);
 }
 
+int cur = ParamUtil.getInteger(request, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_CUR);
+
 long groupId = ParamUtil.getLong(request, "groupId");
 
 Group group = themeDisplay.getScopeGroup();
@@ -58,6 +60,7 @@ request.setAttribute("search.jsp-portletURL", portletURL);
 
 <aui:form action="<%= searchURL %>" method="get" name="fm" onSubmit='<%= "event.preventDefault();" %>'>
 	<liferay-portlet:renderURLParams varImpl="searchURL" />
+	<aui:input name="cur" type="hidden" value="<%= cur %>" />
 	<aui:input name="format" type="hidden" value="<%= format %>" />
 
 	<aui:fieldset>
@@ -146,6 +149,8 @@ request.setAttribute("search.jsp-portletURL", portletURL);
 		pageLinks.delegate(
 			'click',
 			function(event) {
+				document.<portlet:namespace />fm.<portlet:namespace /><%= SearchContainer.DEFAULT_CUR_PARAM %>.value = parseInt(document.<portlet:namespace />fm.<portlet:namespace /><%= SearchContainer.DEFAULT_CUR_PARAM %>.value) - 1;
+
 				submitForm(document.<portlet:namespace />fm);
 
 				event.preventDefault();
@@ -156,7 +161,7 @@ request.setAttribute("search.jsp-portletURL", portletURL);
 		pageLinks.delegate(
 			'click',
 			function(event) {
-				document.<portlet:namespace />fm.<portlet:namespace /><%= SearchContainer.DEFAULT_CUR_PARAM %>.value = parseInt(document.<portlet:namespace />fm.<portlet:namespace /><%= SearchContainer.DEFAULT_CUR_PARAM %>.value) + 2;
+				document.<portlet:namespace />fm.<portlet:namespace /><%= SearchContainer.DEFAULT_CUR_PARAM %>.value = parseInt(document.<portlet:namespace />fm.<portlet:namespace /><%= SearchContainer.DEFAULT_CUR_PARAM %>.value) + 1;
 
 				submitForm(document.<portlet:namespace />fm);
 


### PR DESCRIPTION
Hi Zsolt,

As the "cur" param is not included in the form by default the value will be 0 and is replaced to 1. This fix follows the pattern as the "more" button's behavior and fixes this issue.

Regards,
Vilmos
