### PR TITLE
LPS-28495 Prepare Validator.isHostName() validator to recognize IPv6 addresses as well

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/Validator.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Validator.java
@@ -525,8 +525,9 @@ public class Validator {
 		}
 
 		for (char c : nameCharArray) {
-			if (!isChar(c) && !isDigit(c) && (c != CharPool.DASH) &&
-				(c != CharPool.PERIOD)) {
+			if (!isChar(c) && !isDigit(c) && (c != CharPool.COLON) &&
+				(c != CharPool.CLOSE_BRACKET) && (c != CharPool.DASH) &&
+				(c != CharPool.OPEN_BRACKET) && (c != CharPool.PERIOD)) {
 
 				return false;
 			}


### PR DESCRIPTION
Hi Zsolt,

During alanyzing an issue I found this bug and fixed it.

Regards,
Vilmos
