### PR TITLE
[TECHNICAL SUPPORT] LPS-28614 Disable dynamic resize of images in Creole editor

### DIFF
--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
@@ -31,6 +31,8 @@ if (wikiPageResourcePrimKey > 0) {
 }
 %>
 
+CKEDITOR.config.disableObjectResizing=true;
+
 CKEDITOR.config.height = 265;
 
 CKEDITOR.config.removePlugins = [


### PR DESCRIPTION
Hi Zsolt,

In LPS-28428 I fixed Image resize problem on the Image selector UI by removing the controls. Further more in thi sissue the dynamic resize is disabled as well. So there no option left to resize the image and is good as Creole 1.0 doesn't implement image size definition.

Regards,
Vilmos
