### PR TITLE
LPS-28364 Further performance improvements and bug fixes

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -74,6 +74,8 @@ public class PropsValues {
 
 	public static final boolean ASSET_ENTRY_INCREMENT_VIEW_COUNTER_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.ASSET_ENTRY_INCREMENT_VIEW_COUNTER_ENABLED));
 
+	public static final boolean ASSET_ENTRY_NESTEDLOOP_JOIN_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.ASSET_ENTRY_NESTEDLOOP_JOIN_ENABLED), false); 
+
 	public static final String ASSET_ENTRY_VALIDATOR = PropsUtil.get(PropsKeys.ASSET_ENTRY_VALIDATOR);
 
 	public static final int ASSET_FILTER_SEARCH_LIMIT = GetterUtil.getInteger(PropsUtil.get(PropsKeys.ASSET_FILTER_SEARCH_LIMIT));

--- a/portal-impl/src/custom-sql/asset.xml
+++ b/portal-impl/src/custom-sql/asset.xml
@@ -162,7 +162,7 @@
 						AssetEntries_AssetCategories
 					WHERE
 						(AssetEntries_AssetCategories.entryId = AssetEntry.entryId) AND
-						(AssetEntries_AssetCategories.categoryId IN ([$CATEGORY_ID$]))
+						([$CATEGORY_IDS$])
 				)
 		]]>
 	</sql>

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -95,8 +95,10 @@ public interface PropsKeys {
 
 	public static final String ASSET_ENTRY_INCREMENT_VIEW_COUNTER_ENABLED = "asset.entry.increment.view.counter.enabled";
 
-	public static final String ASSET_ENTRY_VALIDATOR = "asset.entry.validator";
+	public static final String ASSET_ENTRY_NESTEDLOOP_JOIN_ENABLED = "asset.entry.nestedloop.join.enabled";
 
+	public static final String ASSET_ENTRY_VALIDATOR = "asset.entry.validator";
+	
 	public static final String ASSET_FILTER_SEARCH_LIMIT = "asset.filter.search.limit";
 
 	public static final String ASSET_PUBLISHER_DISPLAY_STYLES = "asset.publisher.display.styles";

--- a/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
@@ -529,6 +529,32 @@ public class AssetEntryQuery {
 		return _toString;
 	}
 
+	@Override
+	public int hashCode() {
+		return toString().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (obj == null) {
+			return false;
+		}
+
+		if (!(obj instanceof AssetEntryQuery)) {
+			return false;
+		}
+
+
+		String _this = this.toString();
+		String _other = obj.toString();
+
+		return _this.equals(_other);
+	}
+
 	private long[] _flattenTagIds(long[][] tagIdsArray) {
 		List<Long> tagIdsList = new ArrayList<Long>();
 


### PR DESCRIPTION
Hi,

I've found a few points for improvement in terms of Asset publisher as we discussed previously.
- ORA-01795 might occur on Oracle if there are more than 1000 category IDs selected.
- Property asset.entry.nestedloop.join.enabled has been introduced to select only entry IDs from the DB
  and fetch individual records one-by-one from EntityCache (this part contained an LRU cache, but I removed that after our discussion).

Cheers,
Laci.
