### PR TITLE
[TECHNICAL SUPPORT] LPS-29334 Fixing BBCode parse problem with trailing line endings

### DIFF
--- a/portal-impl/src/com/liferay/portal/parsers/bbcode/BBCodeParser.java
+++ b/portal-impl/src/com/liferay/portal/parsers/bbcode/BBCodeParser.java
@@ -17,6 +17,7 @@ package com.liferay.portal.parsers.bbcode;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.IntegerWrapper;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +54,8 @@ public class BBCodeParser {
 
 	public List<BBCodeItem> parse(String text) {
 		List<BBCodeItem> bbCodeItems = new ArrayList<BBCodeItem>();
+
+		text = StringUtil.trimTrailing(text);
 
 		BBCodeLexer bbCodeLexer = new BBCodeLexer(text);
 		Stack<String> tags = new Stack<String>();


### PR DESCRIPTION
Hi Zsolt,

If a custom porlet uses e.g: CKEditor or anything else to get the user input for MBMessage and they don't trim the trailing line endings the poratal throws exceptions, though the saving of the message is successful, but the log has errors.

The fix I made is to trim the trailing whitespaces with StringUtil.trimTrailing() in the parse method of BBCodeParser before processing the text.

Regards,
Vilmos
