### PR TITLE
[TECHNICAL SUPPORT] LPS-29594 Percentage bar's CSS classes in polls display don't exist

### DIFF
--- a/portal-web/docroot/html/portlet/polls/view_question_results.jspf
+++ b/portal-web/docroot/html/portlet/polls/view_question_results.jspf
@@ -75,8 +75,8 @@ for (int i = 0; i < choices.size(); i++) {
 		<td>
 			<table border="0" cellpadding="0" cellspacing="0">
 			<tr>
-				<td class="alpha"><img alt="" border="0" height="5" hspace="0" src="<%= themeDisplay.getPathThemeImages() %>/spacer.png" vspace="0" width="<%= votesPercentWidth %>" /></td>
-				<td class="beta"><img alt="" border="0" height="5" hspace="0" src="<%= themeDisplay.getPathThemeImages() %>/spacer.png" vspace="0" width="<%= votesPixelWidth - votesPercentWidth %>" /></td>
+				<td class="lfr-percentage-bar"><img alt="" border="0" height="5" hspace="0" src="<%= themeDisplay.getPathThemeImages() %>/spacer.png" vspace="0" width="<%= votesPercentWidth %>" /></td>
+				<td class="lfr-percentage-bar-spacer"><img alt="" border="0" height="5" hspace="0" src="<%= themeDisplay.getPathThemeImages() %>/spacer.png" vspace="0" width="<%= votesPixelWidth - votesPercentWidth %>" /></td>
 			</tr>
 			</table>
 		</td>

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
@@ -337,6 +337,16 @@ hr, .separator {
 	}
 }
 
+.lfr-percentage-bar {
+	background: #A7CEDF !important;
+	padding: 0px !important;
+}
+
+.lfr-percentage-bar-spacer {
+	background: #FFF !important;
+	padding: 0px !important;
+}
+
 .lfr-portlet-title-editable-content .aui-field {
 	display: inline;
 	float: none;


### PR DESCRIPTION
Hi Zsolt,

This issue is exists even in 5.2.x. The problem is originated from three things:

First thing is that the percentage bar has "alpha" and "beta" named CSS classes for rendering, but they are not exists in any of our CSS files.

Second thing is CSS classnames like alpha and beta is not fits in the naming conventions, hence I started with a source format for fixing this issue.

Third thing is another issue, but related to this one and should be fixed in the same place, so I've merged it to this ticket: There are paddings set for the TD elements, that makes the percentage bar's spacer always visible even if there's 100% is displayed. I've removed the padding from the affected classes, so it looks fine now.

Please let me know if you have any concerns,

Regards,
Vilmos
