### PR TITLE
[TECHNICAL SUPPORT] LPS-30255

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/http/ContactServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/ContactServiceHttp.java
@@ -14,6 +14,13 @@
 
 package com.liferay.portal.service.http;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
+import com.liferay.portal.security.auth.HttpPrincipal;
+import com.liferay.portal.service.ContactServiceUtil;
+
 /**
  * <p>
  * This class provides a HTTP utility for the
@@ -45,4 +52,127 @@ package com.liferay.portal.service.http;
  * @generated
  */
 public class ContactServiceHttp {
+	public static com.liferay.portal.model.Contact getContact(
+		HttpPrincipal httpPrincipal, long contactId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(ContactServiceUtil.class.getName(),
+					"getContact", _getContactParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, contactId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portal.model.Contact)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static java.util.List<com.liferay.portal.model.Contact> getContacts(
+		HttpPrincipal httpPrincipal, long classNameId, long classPK, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(ContactServiceUtil.class.getName(),
+					"getContacts", _getContactsParameterTypes1);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					classNameId, classPK, start, end, orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portal.model.Contact>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static int getContactsCount(HttpPrincipal httpPrincipal,
+		long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(ContactServiceUtil.class.getName(),
+					"getContactsCount", _getContactsCountParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					classNameId, classPK);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(ContactServiceHttp.class);
+	private static final Class<?>[] _getContactParameterTypes0 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _getContactsParameterTypes1 = new Class[] {
+			long.class, long.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _getContactsCountParameterTypes2 = new Class[] {
+			long.class, long.class
+		};
 }

--- a/portal-impl/src/com/liferay/portal/service/http/ContactServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/ContactServiceSoap.java
@@ -14,6 +14,12 @@
 
 package com.liferay.portal.service.http;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.service.ContactServiceUtil;
+
+import java.rmi.RemoteException;
+
 /**
  * <p>
  * This class provides a SOAP utility for the
@@ -57,4 +63,51 @@ package com.liferay.portal.service.http;
  * @generated
  */
 public class ContactServiceSoap {
+	public static com.liferay.portal.model.ContactSoap getContact(
+		long contactId) throws RemoteException {
+		try {
+			com.liferay.portal.model.Contact returnValue = ContactServiceUtil.getContact(contactId);
+
+			return com.liferay.portal.model.ContactSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.portal.model.ContactSoap[] getContacts(
+		long classNameId, long classPK, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.portal.model.Contact> returnValue = ContactServiceUtil.getContacts(classNameId,
+					classPK, start, end, orderByComparator);
+
+			return com.liferay.portal.model.ContactSoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static int getContactsCount(long classNameId, long classPK)
+		throws RemoteException {
+		try {
+			int returnValue = ContactServiceUtil.getContactsCount(classNameId,
+					classPK);
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(ContactServiceSoap.class);
 }

--- a/portal-impl/src/com/liferay/portal/service/http/ContactService_deploy.wsdd
+++ b/portal-impl/src/com/liferay/portal/service/http/ContactService_deploy.wsdd
@@ -2,8 +2,27 @@
 
 <deployment xmlns="http://xml.apache.org/axis/wsdd/" xmlns:java="http://xml.apache.org/axis/wsdd/providers/java">
 	<service name="Portal_ContactService" provider="java:RPC" style="rpc" use="encoded">
-		<parameter name="allowedMethods" value="*" />
+		<arrayMapping xmlns:ns="urn:http.service.portal.liferay.com" xmlns:cmp-ns="http://model.portal.liferay.com" qname="ns:ArrayOf_tns2_ContactSoap" type="java:com.liferay.portal.model.ContactSoap[]" innerType="cmp-ns:ContactSoap" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></arrayMapping>
+		<arrayMapping xmlns:ns="urn:http.service.portal.liferay.com" xmlns:cmp-ns="http://www.w3.org/2001/XMLSchema" qname="ns:ArrayOf_xsd_string" type="java:java.lang.String[]" innerType="cmp-ns:string" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></arrayMapping>
+		<typeMapping xmlns:ns="http://model.portal.liferay.com" qname="ns:ContactSoap" type="java:com.liferay.portal.model.ContactSoap" serializer="org.apache.axis.encoding.ser.BeanSerializerFactory" deserializer="org.apache.axis.encoding.ser.BeanDeserializerFactory" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></typeMapping>
+		<typeMapping xmlns:ns="http://util.kernel.portal.liferay.com" qname="ns:OrderByComparator" type="java:com.liferay.portal.kernel.util.OrderByComparator" serializer="org.apache.axis.encoding.ser.BeanSerializerFactory" deserializer="org.apache.axis.encoding.ser.BeanDeserializerFactory" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></typeMapping>
+		<operation xmlns:operNS="urn:http.service.portal.liferay.com" xmlns:rtns="http://model.portal.liferay.com" name="getContact" qname="operNS:getContact" returnQName="getContactReturn" returnType="rtns:ContactSoap" soapAction="">
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="contactId" type="tns:long"></parameter>
+		</operation>
+		<operation xmlns:operNS="urn:http.service.portal.liferay.com" xmlns:rtns="http://www.w3.org/2001/XMLSchema" name="getContactsCount" qname="operNS:getContactsCount" returnQName="getContactsCountReturn" returnType="rtns:int" soapAction="">
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classNameId" type="tns:long"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classPK" type="tns:long"></parameter>
+		</operation>
+		<operation xmlns:operNS="urn:http.service.portal.liferay.com" xmlns:rtns="urn:http.service.portal.liferay.com" xmlns:tns2="http://model.portal.liferay.com" name="getContacts" qname="operNS:getContacts" returnQName="getContactsReturn" returnType="rtns:ArrayOf_tns2_ContactSoap" returnItemType="tns2:ContactSoap" soapAction="">
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classNameId" type="tns:long"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classPK" type="tns:long"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="start" type="tns:int"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="end" type="tns:int"></parameter>
+			<parameter xmlns:tns="http://util.kernel.portal.liferay.com" qname="orderByComparator" type="tns:OrderByComparator"></parameter>
+		</operation>
+		<parameter name="allowedMethods" value="getContact getContacts getContactsCount" />
 		<parameter name="className" value="com.liferay.portal.service.http.ContactServiceSoap" />
+		<parameter name="schemaUnqualified" value="http://model.portal.liferay.com,http://util.kernel.portal.liferay.com,urn:http.service.portal.liferay.com" />
 		<parameter name="typeMappingVersion" value="1.2" />
 		<parameter name="wsdlPortType" value="ContactServiceSoap" />
 		<parameter name="wsdlServiceElement" value="ContactServiceSoapService" />

--- a/portal-impl/src/com/liferay/portal/service/impl/ContactServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ContactServiceImpl.java
@@ -14,10 +14,53 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.model.Contact;
+import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.service.base.ContactServiceBaseImpl;
+import com.liferay.portal.service.permission.CommonPermissionUtil;
+
+import java.util.List;
 
 /**
  * @author Brian Wing Shun Chan
+ * @author Vilmos Papp
  */
 public class ContactServiceImpl extends ContactServiceBaseImpl {
+
+	public Contact getContact(long contactId)
+		throws PortalException, SystemException {
+
+		Contact contact = contactLocalService.getContact(contactId);
+
+		CommonPermissionUtil.check(
+			getPermissionChecker(), contact.getClassNameId(),
+			contact.getClassPK(), ActionKeys.VIEW);
+
+		return contactLocalService.getContact(contactId);
+	}
+
+	public List<Contact> getContacts(
+			long classNameId, long classPK, int start, int end,
+			OrderByComparator orderByComparator)
+		throws PortalException, SystemException {
+
+		CommonPermissionUtil.check(
+			getPermissionChecker(), classNameId, classPK, ActionKeys.VIEW);
+
+		return contactLocalService.getContacts(
+			classNameId, classPK, start, end, orderByComparator);
+	}
+
+	public int getContactsCount(long classNameId, long classPK)
+		throws PortalException, SystemException {
+
+		CommonPermissionUtil.check(
+			getPermissionChecker(), classNameId, classPK, ActionKeys.VIEW);
+
+		return contactLocalService.getContactsCount(classNameId, classPK);
+	}
+
 }

--- a/portal-impl/src/com/liferay/portal/service/permission/CommonPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/CommonPermissionImpl.java
@@ -60,6 +60,13 @@ public class CommonPermissionImpl implements CommonPermission {
 			OrganizationPermissionUtil.check(
 				permissionChecker, classPK, actionId);
 		}
+		else if (className.equals(User.class.getName())) {
+			User user = UserLocalServiceUtil.getUserById(classPK);
+
+			UserPermissionUtil.check(
+				permissionChecker, user.getUserId(), user.getOrganizationIds(),
+				actionId);
+		}
 		else {
 			if (_log.isWarnEnabled()) {
 				_log.warn("Invalid class name " + className);

--- a/portal-service/src/com/liferay/portal/service/ContactService.java
+++ b/portal-service/src/com/liferay/portal/service/ContactService.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.transaction.Isolation;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.security.ac.AccessControlled;
 
@@ -58,4 +59,21 @@ public interface ContactService extends BaseService {
 	* @param beanIdentifier the Spring bean ID for this bean
 	*/
 	public void setBeanIdentifier(java.lang.String beanIdentifier);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public com.liferay.portal.model.Contact getContact(long contactId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.Contact> getContacts(
+		long classNameId, long classPK, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getContactsCount(long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
 }

--- a/portal-service/src/com/liferay/portal/service/ContactServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/ContactServiceUtil.java
@@ -55,6 +55,28 @@ public class ContactServiceUtil {
 		getService().setBeanIdentifier(beanIdentifier);
 	}
 
+	public static com.liferay.portal.model.Contact getContact(long contactId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService().getContact(contactId);
+	}
+
+	public static java.util.List<com.liferay.portal.model.Contact> getContacts(
+		long classNameId, long classPK, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getContacts(classNameId, classPK, start, end,
+			orderByComparator);
+	}
+
+	public static int getContactsCount(long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService().getContactsCount(classNameId, classPK);
+	}
+
 	public static ContactService getService() {
 		if (_service == null) {
 			_service = (ContactService)PortalBeanLocatorUtil.locate(ContactService.class.getName());

--- a/portal-service/src/com/liferay/portal/service/ContactServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/ContactServiceWrapper.java
@@ -47,6 +47,27 @@ public class ContactServiceWrapper implements ContactService,
 		_contactService.setBeanIdentifier(beanIdentifier);
 	}
 
+	public com.liferay.portal.model.Contact getContact(long contactId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _contactService.getContact(contactId);
+	}
+
+	public java.util.List<com.liferay.portal.model.Contact> getContacts(
+		long classNameId, long classPK, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _contactService.getContacts(classNameId, classPK, start, end,
+			orderByComparator);
+	}
+
+	public int getContactsCount(long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _contactService.getContactsCount(classNameId, classPK);
+	}
+
 	/**
 	 * @deprecated Renamed to {@link #getWrappedService}
 	 */

--- a/portal-web/docroot/WEB-INF/server-config.wsdd
+++ b/portal-web/docroot/WEB-INF/server-config.wsdd
@@ -195,8 +195,27 @@
 		<parameter name="wsdlTargetNamespace" value="urn:http.service.portal.liferay.com" />
 	</service>
 	<service name="Portal_ContactService" provider="java:RPC" style="rpc" use="encoded">
-		<parameter name="allowedMethods" value="*" />
+		<arrayMapping xmlns:ns="urn:http.service.portal.liferay.com" xmlns:cmp-ns="http://model.portal.liferay.com" qname="ns:ArrayOf_tns2_ContactSoap" type="java:com.liferay.portal.model.ContactSoap[]" innerType="cmp-ns:ContactSoap" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></arrayMapping>
+		<arrayMapping xmlns:ns="urn:http.service.portal.liferay.com" xmlns:cmp-ns="http://www.w3.org/2001/XMLSchema" qname="ns:ArrayOf_xsd_string" type="java:java.lang.String[]" innerType="cmp-ns:string" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></arrayMapping>
+		<typeMapping xmlns:ns="http://model.portal.liferay.com" qname="ns:ContactSoap" type="java:com.liferay.portal.model.ContactSoap" serializer="org.apache.axis.encoding.ser.BeanSerializerFactory" deserializer="org.apache.axis.encoding.ser.BeanDeserializerFactory" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></typeMapping>
+		<typeMapping xmlns:ns="http://util.kernel.portal.liferay.com" qname="ns:OrderByComparator" type="java:com.liferay.portal.kernel.util.OrderByComparator" serializer="org.apache.axis.encoding.ser.BeanSerializerFactory" deserializer="org.apache.axis.encoding.ser.BeanDeserializerFactory" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"></typeMapping>
+		<operation xmlns:operNS="urn:http.service.portal.liferay.com" xmlns:rtns="http://model.portal.liferay.com" name="getContact" qname="operNS:getContact" returnQName="getContactReturn" returnType="rtns:ContactSoap" soapAction="">
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="contactId" type="tns:long"></parameter>
+		</operation>
+		<operation xmlns:operNS="urn:http.service.portal.liferay.com" xmlns:rtns="http://www.w3.org/2001/XMLSchema" name="getContactsCount" qname="operNS:getContactsCount" returnQName="getContactsCountReturn" returnType="rtns:int" soapAction="">
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classNameId" type="tns:long"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classPK" type="tns:long"></parameter>
+		</operation>
+		<operation xmlns:operNS="urn:http.service.portal.liferay.com" xmlns:rtns="urn:http.service.portal.liferay.com" xmlns:tns2="http://model.portal.liferay.com" name="getContacts" qname="operNS:getContacts" returnQName="getContactsReturn" returnType="rtns:ArrayOf_tns2_ContactSoap" returnItemType="tns2:ContactSoap" soapAction="">
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classNameId" type="tns:long"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="classPK" type="tns:long"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="start" type="tns:int"></parameter>
+			<parameter xmlns:tns="http://www.w3.org/2001/XMLSchema" qname="end" type="tns:int"></parameter>
+			<parameter xmlns:tns="http://util.kernel.portal.liferay.com" qname="orderByComparator" type="tns:OrderByComparator"></parameter>
+		</operation>
+		<parameter name="allowedMethods" value="getContact getContacts getContactsCount" />
 		<parameter name="className" value="com.liferay.portal.service.http.ContactServiceSoap" />
+		<parameter name="schemaUnqualified" value="http://model.portal.liferay.com,http://util.kernel.portal.liferay.com,urn:http.service.portal.liferay.com" />
 		<parameter name="typeMappingVersion" value="1.2" />
 		<parameter name="wsdlPortType" value="ContactServiceSoap" />
 		<parameter name="wsdlServiceElement" value="ContactServiceSoapService" />


### PR DESCRIPTION
Hi Zsolt,

This issue is originated from not publishing ContactService methods to remote interfaces, but based on my discussion with Ray and Jorge add\* and delete\* method shouldn't be exposed to not break User and Contact objects' 1:1 relationships.  

Julio reviewed my original fix, and realized, that I used UserPremissionUtil what is not enough as now we can have other objects related to Contact based on classNameId and classPK, so based on this and Máté's guide, I refactored the code to user CommonPermissionUtil instead. Additionally I added User.class for the accepted classes by the CommonPermissionUtil, as if the related object to the Contact object is User then I got an exception because of the permission check.

If you have any concerns, please ask me or Máté who is familiar with the original fix and Julio's comments.

Regards,
Vilmos
