### PR TITLE
LPS-37463 Display right count in portlet export and publish

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_xml_leading_spaces_exclusions.properties
+++ b/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_xml_leading_spaces_exclusions.properties
@@ -3,4 +3,7 @@
 #
 definitions/web-facesconfig_1_2.xml
 portal-web/docroot/dtd/web-facesconfig_1_2.xml
+portal-web/docroot/html/js/editor/fckeditor/_samples/adobeair/application.xml
+portal-web/docroot/html/js/editor/fckeditor/fckpackager.xml
+portal-web/docroot/html/js/editor/fckeditor/fcktemplates.xml
 util-taglib/src/com/liferay/taglib/aui.xml

--- a/portal-impl/src/com/liferay/portlet/blogs/lar/BlogsPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/lar/BlogsPortletDataHandler.java
@@ -135,7 +135,8 @@ public class BlogsPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery actionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksPortletDataHandler.java
@@ -159,7 +159,8 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery entryExportActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
@@ -208,7 +208,8 @@ public class DLPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			final PortletDataContext portletDataContext)
+			final PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery dlFileShortcutActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/lar/DDLPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/lar/DDLPortletDataHandler.java
@@ -118,7 +118,8 @@ public class DDLPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery actionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalContentPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalContentPortletDataHandler.java
@@ -15,10 +15,12 @@
 package com.liferay.portlet.journal.lar;
 
 import com.liferay.portal.kernel.lar.DataLevel;
+import com.liferay.portal.kernel.lar.ManifestSummary;
 import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.lar.PortletDataHandlerBoolean;
 import com.liferay.portal.kernel.lar.PortletDataHandlerControl;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
+import com.liferay.portal.kernel.lar.StagedModelType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -318,6 +320,26 @@ public class JournalContentPortletDataHandler
 		portletDataContext.setScopeGroupId(previousScopeGroupId);
 
 		return portletPreferences;
+	}
+
+	@Override
+	protected void doPrepareManifestSummary(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		if (portletPreferences != null) {
+			ManifestSummary manifestSummary =
+				portletDataContext.getManifestSummary();
+
+			String articleId = portletPreferences.getValue(
+				"articleId", StringPool.BLANK);
+
+			if (Validator.isNotNull(articleId)) {
+				manifestSummary.addModelAdditionCount(
+					new StagedModelType(JournalArticle.class), 1);
+			}
+		}
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
@@ -277,7 +277,8 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery articleActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/layoutprototypes/lar/LayoutPrototypePortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutprototypes/lar/LayoutPrototypePortletDataHandler.java
@@ -109,7 +109,8 @@ public class LayoutPrototypePortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery layoutPrototypeExportActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/layoutsetprototypes/lar/LayoutSetPrototypePortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsetprototypes/lar/LayoutSetPrototypePortletDataHandler.java
@@ -116,7 +116,8 @@ public class LayoutSetPrototypePortletDataHandler
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery layoutSetPrototypeExportActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/messageboards/lar/MBPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/lar/MBPortletDataHandler.java
@@ -207,7 +207,8 @@ public class MBPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery banActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRPortletDataHandler.java
@@ -157,7 +157,8 @@ public class MDRPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery actionsActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/polls/lar/PollsPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/polls/lar/PollsPortletDataHandler.java
@@ -173,7 +173,8 @@ public class PollsPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery choiceActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/portletdisplaytemplate/lar/PortletDisplayTemplatePortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/portletdisplaytemplate/lar/PortletDisplayTemplatePortletDataHandler.java
@@ -128,7 +128,8 @@ public class PortletDisplayTemplatePortletDataHandler
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		for (StagedModelType modeType : stagedModelTypes) {

--- a/portal-impl/src/com/liferay/portlet/usergroupsadmin/lar/UserGroupsAdminPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/usergroupsadmin/lar/UserGroupsAdminPortletDataHandler.java
@@ -108,7 +108,8 @@ public class UserGroupsAdminPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery actionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/usersadmin/lar/UsersAdminPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/lar/UsersAdminPortletDataHandler.java
@@ -114,7 +114,8 @@ public class UsersAdminPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery actionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/wiki/lar/WikiPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/lar/WikiPortletDataHandler.java
@@ -181,7 +181,8 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 
 		ActionableDynamicQuery nodeActionableDynamicQuery =

--- a/portal-impl/test/unit/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtilTest.java
@@ -80,17 +80,19 @@ public class MPIHelperUtilTest {
 
 		SPIRegistryUtil spiRegistryUtil = new SPIRegistryUtil();
 
-		spiRegistryUtil.setSPIRegistry(new SPIRegistryImpl() {
+		spiRegistryUtil.setSPIRegistry(
+			new SPIRegistryImpl() {
 
-			@Override
-			public void registerSPI(SPI spi) {
+				@Override
+				public void registerSPI(SPI spi) {
+				}
+
+				@Override
+				public void unregisterSPI(SPI spi) {
+				}
+
 			}
-
-			@Override
-			public void unregisterSPI(SPI spi) {
-			}
-
-		});
+		);
 	}
 
 	@After
@@ -581,14 +583,12 @@ public class MPIHelperUtilTest {
 
 		Assert.assertTrue(MPIHelperUtil.registerSPIProvider(mockSPIProvider));
 
-		String servletContextName1 = "servletContextName1";
-
 		mockSPI1 = new MockSPI();
 
 		mockSPI1.mpi = MPIHelperUtil.getMPI();
 		mockSPI1.spiConfiguration = new SPIConfiguration(
 			"testId1", "", 8081, "", new String[0],
-			new String[]{servletContextName1});
+			new String[] {"servletContextName1"});
 		mockSPI1.spiProviderName = name;
 
 		logRecords = JDKLoggerTestUtil.configureJDKLogger(
@@ -606,8 +606,6 @@ public class MPIHelperUtilTest {
 
 		logRecords = JDKLoggerTestUtil.configureJDKLogger(
 			MPIHelperUtil.class.getName(), Level.OFF);
-
-		String servletContextName2 = "servletContextName2";
 
 		MessagingConfigurator messagingConfigurator =
 			new AbstractMessagingConfigurator() {
@@ -631,15 +629,15 @@ public class MPIHelperUtilTest {
 			}
 		};
 
-		MessagingConfiguratorRegistry.register(
-			servletContextName2, messagingConfigurator);
+		MessagingConfiguratorRegistry.registerMessagingConfigurator(
+			"servletContextName2", messagingConfigurator);
 
 		MockSPI mockSPI2 = new MockSPI();
 
 		mockSPI2.mpi = MPIHelperUtil.getMPI();
 		mockSPI2.spiConfiguration = new SPIConfiguration(
 			"testId2", "", 8082, "", new String[0],
-			new String[]{servletContextName2});
+			new String[] {"servletContextName2"});
 		mockSPI2.spiProviderName = name;
 
 		Assert.assertTrue(MPIHelperUtil.registerSPI(mockSPI2));

--- a/portal-service/src/com/liferay/portal/kernel/lar/BasePortletDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/BasePortletDataHandler.java
@@ -346,8 +346,17 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 	public void prepareManifestSummary(PortletDataContext portletDataContext)
 		throws PortletDataException {
 
+		prepareManifestSummary(portletDataContext, null);
+	}
+
+	@Override
+	public void prepareManifestSummary(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
 		try {
-			doPrepareManifestSummary(portletDataContext);
+			doPrepareManifestSummary(portletDataContext, portletPreferences);
 		}
 		catch (Exception e) {
 			throw new PortletDataException(e);
@@ -542,7 +551,8 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 	}
 
 	protected void doPrepareManifestSummary(
-			PortletDataContext portletDataContext)
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
 		throws Exception {
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandler.java
@@ -186,6 +186,11 @@ public interface PortletDataHandler {
 	public void prepareManifestSummary(PortletDataContext portletDataContext)
 		throws PortletDataException;
 
+	public void prepareManifestSummary(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException;
+
 	public PortletPreferences processExportPortletPreferences(
 			PortletDataContext portletDataContext, String portletId,
 			PortletPreferences portletPreferences, Element rootElement)

--- a/portal-service/src/com/liferay/portal/kernel/messaging/config/AbstractMessagingConfigurator.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/config/AbstractMessagingConfigurator.java
@@ -83,7 +83,8 @@ public abstract class AbstractMessagingConfigurator
 		String servletContextName = ClassLoaderPool.getContextName(
 			operatingClassLoader);
 
-		MessagingConfiguratorRegistry.register(servletContextName, this);
+		MessagingConfiguratorRegistry.registerMessagingConfigurator(
+			servletContextName, this);
 	}
 
 	@Override
@@ -158,7 +159,8 @@ public abstract class AbstractMessagingConfigurator
 		String servletContextName = ClassLoaderPool.getContextName(
 			operatingClassLoader);
 
-		MessagingConfiguratorRegistry.unregister(servletContextName, this);
+		MessagingConfiguratorRegistry.unregisterMessagingConfigurator(
+			servletContextName, this);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/messaging/config/MessagingConfigurator.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/config/MessagingConfigurator.java
@@ -26,9 +26,11 @@ import java.util.Map;
  */
 public interface MessagingConfigurator {
 
+	public void connect();
+
 	public void destroy();
 
-	public void init();
+	public void disconnect();
 
 	public void setDestinations(List<Destination> destinations);
 

--- a/portal-service/src/com/liferay/portal/kernel/messaging/config/MessagingConfiguratorRegistry.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/config/MessagingConfiguratorRegistry.java
@@ -24,13 +24,13 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class MessagingConfiguratorRegistry {
 
-	public static List<MessagingConfigurator> lookup(
+	public static List<MessagingConfigurator> getMessagingConfigurators(
 		String servletContextName) {
 
 		return _messagingConfigurators.get(servletContextName);
 	}
 
-	public static void register(
+	public static void registerMessagingConfigurator(
 		String servletContextName,
 		MessagingConfigurator messagingConfigurator) {
 
@@ -47,7 +47,7 @@ public class MessagingConfiguratorRegistry {
 		messagingConfigurators.add(messagingConfigurator);
 	}
 
-	public static void unregister(
+	public static void unregisterMessagingConfigurator(
 		String servletContextName,
 		MessagingConfigurator messagingConfigurator) {
 

--- a/portal-service/src/com/liferay/portal/kernel/messaging/config/MessagingConfiguratorRegistry.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/config/MessagingConfiguratorRegistry.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.messaging.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class MessagingConfiguratorRegistry {
+
+	public static List<MessagingConfigurator> lookup(
+		String servletContextName) {
+
+		return _messagingConfigurators.get(servletContextName);
+	}
+
+	public static void register(
+		String servletContextName,
+		MessagingConfigurator messagingConfigurator) {
+
+		List<MessagingConfigurator> messagingConfigurators =
+			_messagingConfigurators.get(servletContextName);
+
+		if (messagingConfigurators == null) {
+			messagingConfigurators = new ArrayList<MessagingConfigurator>();
+
+			_messagingConfigurators.put(
+				servletContextName, messagingConfigurators);
+		}
+
+		messagingConfigurators.add(messagingConfigurator);
+	}
+
+	public static void unregister(
+		String servletContextName,
+		MessagingConfigurator messagingConfigurator) {
+
+		List<MessagingConfigurator> messagingConfigurators =
+			_messagingConfigurators.get(servletContextName);
+
+		if (messagingConfigurators != null) {
+			messagingConfigurators.remove(messagingConfigurator);
+
+			if (messagingConfigurators.isEmpty()) {
+				_messagingConfigurators.remove(servletContextName);
+			}
+		}
+	}
+
+	private static final Map<String, List<MessagingConfigurator>>
+		_messagingConfigurators =
+			new ConcurrentHashMap<String, List<MessagingConfigurator>>();
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
@@ -163,7 +163,7 @@ public class MPIHelperUtil {
 						spiConfiguration.getServletContextNames()) {
 
 					List<MessagingConfigurator> messagingConfigurators =
-						MessagingConfiguratorRegistry.lookup(
+						MessagingConfiguratorRegistry.getMessagingConfigurators(
 							servletContextName);
 
 					if (messagingConfigurators != null) {
@@ -277,7 +277,7 @@ public class MPIHelperUtil {
 						spiConfiguration.getServletContextNames()) {
 
 					List<MessagingConfigurator> messagingConfigurators =
-						MessagingConfiguratorRegistry.lookup(
+						MessagingConfiguratorRegistry.getMessagingConfigurators(
 							servletContextName);
 
 					if (messagingConfigurators != null) {

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
@@ -16,6 +16,8 @@ package com.liferay.portal.kernel.resiliency.mpi;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.config.MessagingConfigurator;
+import com.liferay.portal.kernel.messaging.config.MessagingConfiguratorRegistry;
 import com.liferay.portal.kernel.nio.intraband.Intraband;
 import com.liferay.portal.kernel.nio.intraband.IntrabandFactoryUtil;
 import com.liferay.portal.kernel.resiliency.spi.SPI;
@@ -157,6 +159,22 @@ public class MPIHelperUtil {
 			else {
 				SPIRegistryUtil.registerSPI(spi);
 
+				for (String servletContextName :
+						spiConfiguration.getServletContextNames()) {
+
+					List<MessagingConfigurator> messagingConfigurators =
+						MessagingConfiguratorRegistry.lookup(
+							servletContextName);
+
+					if (messagingConfigurators != null) {
+						for (MessagingConfigurator messagingConfigurator :
+								messagingConfigurators) {
+
+							messagingConfigurator.disconnect();
+						}
+					}
+				}
+
 				if (_log.isInfoEnabled()) {
 					_log.info("Registered SPI " + spi);
 				}
@@ -254,6 +272,22 @@ public class MPIHelperUtil {
 
 			if (_spis.remove(spiKey, spi)) {
 				SPIRegistryUtil.unregisterSPI(spi);
+
+				for (String servletContextName :
+						spiConfiguration.getServletContextNames()) {
+
+					List<MessagingConfigurator> messagingConfigurators =
+						MessagingConfiguratorRegistry.lookup(
+							servletContextName);
+
+					if (messagingConfigurators != null) {
+						for (MessagingConfigurator messagingConfigurator :
+								messagingConfigurators) {
+
+							messagingConfigurator.connect();
+						}
+					}
+				}
 
 				if (_log.isInfoEnabled()) {
 					_log.info("Unregistered SPI " + spi);

--- a/portal-service/src/com/liferay/portal/kernel/util/StreamUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StreamUtil.java
@@ -214,7 +214,7 @@ public class StreamUtil {
 			long length)
 		throws IOException {
 
-		if (length < 0) {
+		if (length <= 0) {
 			length = inputFileChannel.size() - inputFileChannel.position();
 		}
 

--- a/portal-service/test/unit/com/liferay/portal/security/auth/DefaultFullNameGeneratorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/security/auth/DefaultFullNameGeneratorTest.java
@@ -25,26 +25,24 @@ import org.junit.Test;
 public class DefaultFullNameGeneratorTest {
 
 	@Test
-	public void testBuildInvalidFullName() {
+	public void testNormalLengthGetFullName() {
+		String fullName = _defaultDefaultFullNameGenerator.getFullName(
+			"Test", "Test", "Test");
+
+		Assert.assertTrue(
+			fullName.length() < UserConstants.FULL_NAME_MAX_LENGTH);
+		Assert.assertEquals("Test Test Test", fullName);
+	}
+
+	@Test
+	public void testVeryLongLengthGetFullName() {
 		String fullName = _defaultDefaultFullNameGenerator.getFullName(
 			"ThisShouldBeAVeryLongName", "ThisShouldBeAVeryLongMiddleName",
 			"ThisShouldBeAVeryLongLastName");
 
 		Assert.assertTrue(
 			fullName.length() < UserConstants.FULL_NAME_MAX_LENGTH);
-
 		Assert.assertEquals("T T ThisShouldBeAVeryLongLastName", fullName);
-	}
-
-	@Test
-	public void testBuildValidFullName() {
-		String fullName = _defaultDefaultFullNameGenerator.getFullName(
-			"Test", "Test", "Test");
-
-		Assert.assertTrue(
-			fullName.length() < UserConstants.FULL_NAME_MAX_LENGTH);
-
-		Assert.assertEquals("Test Test Test", fullName);
 	}
 
 	private DefaultFullNameGenerator _defaultDefaultFullNameGenerator =

--- a/portal-service/test/unit/com/liferay/portal/security/auth/DefaultFullNameGeneratorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/security/auth/DefaultFullNameGeneratorTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.auth;
+
+import com.liferay.portal.model.UserConstants;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Miguel Pastor
+ */
+public class DefaultFullNameGeneratorTest {
+
+	@Test
+	public void testBuildInvalidFullName() {
+		String fullName = _defaultDefaultFullNameGenerator.getFullName(
+			"ThisShouldBeAVeryLongName", "ThisShouldBeAVeryLongMiddleName",
+			"ThisShouldBeAVeryLongLastName");
+
+		Assert.assertTrue(
+			fullName.length() < UserConstants.FULL_NAME_MAX_LENGTH);
+
+		Assert.assertEquals("T T ThisShouldBeAVeryLongLastName", fullName);
+	}
+
+	@Test
+	public void testBuildValidFullName() {
+		String fullName = _defaultDefaultFullNameGenerator.getFullName(
+			"Test", "Test", "Test");
+
+		Assert.assertTrue(
+			fullName.length() < UserConstants.FULL_NAME_MAX_LENGTH);
+
+		Assert.assertEquals("Test Test Test", fullName);
+	}
+
+	private DefaultFullNameGenerator _defaultDefaultFullNameGenerator =
+		new DefaultFullNameGenerator();
+
+}

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1620,7 +1620,6 @@
 		<portlet-name>154</portlet-name>
 		<icon>/html/icons/wiki.png</icon>
 		<struts-path>wiki_admin</struts-path>
-		<configuration-action-class>com.liferay.portlet.wiki.action.ConfigurationActionImpl</configuration-action-class>
 		<portlet-url-class>com.liferay.portal.struts.StrutsActionPortletURL</portlet-url-class>
 		<portlet-data-handler-class>com.liferay.portlet.wiki.lar.WikiPortletDataHandler</portlet-data-handler-class>
 		<control-panel-entry-category>site_administration.content</control-panel-entry-category>

--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -46,34 +46,46 @@
 
 	<aui:nav-bar>
 		<aui:nav>
-			<aui:nav-item dropdown="<%= true %>" iconClass="icon-plus" label='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "add-new" : "add-new-in-x", new Object[] {HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale))}) %>'>
+			<c:choose>
+				<c:when test="<%= addPortletURLs.size() == 1 %>">
 
-				<%
-				for (Map.Entry<String, PortletURL> entry : addPortletURLs.entrySet()) {
+					<%
+					Map.Entry<String, PortletURL> entry = addPortletURLs.entrySet().iterator().next();
+
 					String message = _getMessage(entry.getKey(), addPortletURLs, locale);
 					%>
 
-					<c:choose>
-						<c:when test="<%= addPortletURLs.size() == 1 %>">
+					<aui:nav-item
+						href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
+						iconClass="icon-file"
+						label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message)) %>'
+					/>
+				</c:when>
+				<c:otherwise>
+					<aui:nav-item
+						dropdown="<%= true %>"
+						iconClass="icon-plus"
+						label='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "add-new" : "add-new-in-x", new Object[] {HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale))}) %>'
+					>
+
+						<%
+						for (Map.Entry<String, PortletURL> entry : addPortletURLs.entrySet()) {
+							String message = _getMessage(entry.getKey(), addPortletURLs, locale);
+						%>
+
 							<aui:nav-item
 								href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
 								iconClass="icon-file"
-								label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message)) %>'
+								label="<%= HtmlUtil.escape(message) %>"
 							/>
-						</c:when>
-						<c:otherwise>
-							<aui:nav-item
-								href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
-								iconClass="icon-file"
-								label="<%= HtmlUtil.escape(message) %>" />
-						</c:otherwise>
-					</c:choose>
 
-				<%
-				}
-				%>
+						<%
+						}
+						%>
 
-			</aui:nav-item>
+					</aui:nav-item>
+				</c:otherwise>
+			</c:choose>
 		</aui:nav>
 	</aui:nav-bar>
 </c:if>

--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -50,7 +50,11 @@
 				<c:when test="<%= addPortletURLs.size() == 1 %>">
 
 					<%
-					Map.Entry<String, PortletURL> entry = addPortletURLs.entrySet().iterator().next();
+					Set<Map.Entry<String, PortletURL>> addPortletURLsSet = addPortletURLs.entrySet();
+
+					Iterator<Map.Entry<String, PortletURL>> iterator = addPortletURLsSet.iterator();
+
+					Map.Entry<String, PortletURL> entry = iterator.next();
 
 					String message = _getMessage(entry.getKey(), addPortletURLs, locale);
 					%>

--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -52,38 +52,12 @@
 				for (Map.Entry<String, PortletURL> entry : addPortletURLs.entrySet()) {
 					String className = entry.getKey();
 
-					String message = null;
-
-					int pos = className.indexOf(AssetUtil.CLASSNAME_SEPARATOR);
-
-					if (pos != -1) {
-						message = className.substring(pos + AssetUtil.CLASSNAME_SEPARATOR.length());
-
-						className = className.substring(0, pos);
-					}
-
-					AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(className);
-
-					if (pos == -1) {
-						message = assetRendererFactory.getTypeName(locale, AssetUtil.hasSubtype(className, addPortletURLs));
-					}
+					String message = _getMessage(className, addPortletURLs, locale);
 
 					PortletURL addPortletURL = entry.getValue();
 
-					addPortletURL.setParameter("groupId", String.valueOf(groupId));
-					addPortletURL.setParameter("showHeader", Boolean.FALSE.toString());
-
-					String addPortletURLString = addPortletURL.toString();
-
-					addPortletURLString = HttpUtil.addParameter(addPortletURLString, "doAsGroupId", groupId);
-					addPortletURLString = HttpUtil.addParameter(addPortletURLString, "refererPlid", plid);
-
-					if (defaultAssetPublisher) {
-						addPortletURLString = HttpUtil.addParameter(addPortletURLString, "layoutUuid", layout.getUuid());
-					}
-
-					String taglibEditURL = "javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, id: '" + liferayPortletResponse.getNamespace() + "editAsset', title: '" + HtmlUtil.escapeJS(LanguageUtil.format(pageContext, "new-x", HtmlUtil.escape(message))) + "', uri: '" + HtmlUtil.escapeJS(addPortletURLString) + "'});";
-				%>
+					String taglibEditURL = _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse);
+					%>
 
 					<c:choose>
 						<c:when test="<%= addPortletURLs.size() == 1 %>">
@@ -102,3 +76,41 @@
 		</aui:nav>
 	</aui:nav-bar>
 </c:if>
+
+<%!
+private String _getMessage(String className, Map<String, PortletURL> addPortletURLs, Locale locale) {
+	String message = null;
+
+	int pos = className.indexOf(AssetUtil.CLASSNAME_SEPARATOR);
+
+	if (pos != -1) {
+		message = className.substring(pos + AssetUtil.CLASSNAME_SEPARATOR.length());
+
+		className = className.substring(0, pos);
+	}
+
+	AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(className);
+
+	if (pos == -1) {
+		message = assetRendererFactory.getTypeName(locale, AssetUtil.hasSubtype(className, addPortletURLs));
+	}
+
+	return message;
+}
+
+private String _getURL(long groupId, long plid, PortletURL addPortletURL, String message, boolean defaultAssetPublisher, Layout layout, PageContext pageContext, LiferayPortletResponse liferayPortletResponse) {
+	addPortletURL.setParameter("groupId", String.valueOf(groupId));
+	addPortletURL.setParameter("showHeader", Boolean.FALSE.toString());
+
+	String addPortletURLString = addPortletURL.toString();
+
+	addPortletURLString = HttpUtil.addParameter(addPortletURLString, "doAsGroupId", groupId);
+	addPortletURLString = HttpUtil.addParameter(addPortletURLString, "refererPlid", plid);
+
+	if (defaultAssetPublisher) {
+		addPortletURLString = HttpUtil.addParameter(addPortletURLString, "layoutUuid", layout.getUuid());
+	}
+
+	return "javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, id: '" + liferayPortletResponse.getNamespace() + "editAsset', title: '" + HtmlUtil.escapeJS(LanguageUtil.format(pageContext, "new-x", HtmlUtil.escape(message))) + "', uri: '" + HtmlUtil.escapeJS(addPortletURLString) + "'});";
+}
+%>

--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -50,21 +50,22 @@
 
 				<%
 				for (Map.Entry<String, PortletURL> entry : addPortletURLs.entrySet()) {
-					String className = entry.getKey();
-
-					String message = _getMessage(className, addPortletURLs, locale);
-
-					PortletURL addPortletURL = entry.getValue();
-
-					String taglibEditURL = _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse);
+					String message = _getMessage(entry.getKey(), addPortletURLs, locale);
 					%>
 
 					<c:choose>
 						<c:when test="<%= addPortletURLs.size() == 1 %>">
-							<aui:nav-item href="<%= taglibEditURL %>" iconClass="icon-file" label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message)) %>' />
+							<aui:nav-item
+								href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
+								iconClass="icon-file"
+								label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message)) %>'
+							/>
 						</c:when>
 						<c:otherwise>
-							<aui:nav-item href="<%= taglibEditURL %>" iconClass="icon-file" label="<%= HtmlUtil.escape(message) %>" />
+							<aui:nav-item
+								href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
+								iconClass="icon-file"
+								label="<%= HtmlUtil.escape(message) %>" />
 						</c:otherwise>
 					</c:choose>
 

--- a/portal-web/docroot/html/portlet/portlet_configuration/export_portlet.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/export_portlet.jsp
@@ -127,7 +127,7 @@ portletURL.setParameter("tabs3", "all-export-processes");
 
 					PortletDataContext portletDataContext = PortletDataContextFactoryUtil.createPreparePortletDataContext(themeDisplay, startDate, endDate);
 
-					portletDataHandler.prepareManifestSummary(portletDataContext);
+					portletDataHandler.prepareManifestSummary(portletDataContext, portletPreferences);
 
 					ManifestSummary manifestSummary = portletDataContext.getManifestSummary();
 

--- a/portal-web/docroot/html/portlet/portlet_configuration/publish_portlet.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/publish_portlet.jsp
@@ -181,7 +181,7 @@ portletURL.setParameter("tabs3", "all-publication-processes");
 
 							PortletDataContext portletDataContext = PortletDataContextFactoryUtil.createPreparePortletDataContext(themeDisplay, startDate, endDate);
 
-							portletDataHandler.prepareManifestSummary(portletDataContext);
+							portletDataHandler.prepareManifestSummary(portletDataContext, portletPreferences);
 
 							ManifestSummary manifestSummary = portletDataContext.getManifestSummary();
 

--- a/util-java/test/unit/com/liferay/util/PwdGeneratorTest.java
+++ b/util-java/test/unit/com/liferay/util/PwdGeneratorTest.java
@@ -21,6 +21,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
+ * <p>
+ * See http://issues.liferay.com/browse/LPS-37502.
+ * </p>
+ *
  * @author Brian Wing Shun Chan
  */
 public class PwdGeneratorTest {
@@ -63,11 +67,6 @@ public class PwdGeneratorTest {
 
 		Assert.assertTrue(delta < _MAX_SECURE_DELTA);
 	}
-
-	/*
-	* See http://issues.liferay.com/browse/LPS-37502 to see how these values
-	* have been calculated
-	*/
 
 	private static final long _MAX_DELTA = 1600;
 

--- a/util-java/test/unit/com/liferay/util/PwdGeneratorTest.java
+++ b/util-java/test/unit/com/liferay/util/PwdGeneratorTest.java
@@ -41,7 +41,7 @@ public class PwdGeneratorTest {
 			_log.info("Generated 100 thousand passwords in " + delta + " ms");
 		}
 
-		Assert.assertTrue(delta < 1000);
+		Assert.assertTrue(delta < _MAX_DELTA);
 	}
 
 	@Test
@@ -61,8 +61,17 @@ public class PwdGeneratorTest {
 				"Generated 100 thousand secure passwords in " + delta + " ms");
 		}
 
-		Assert.assertTrue(delta < 2000);
+		Assert.assertTrue(delta < _MAX_SECURE_DELTA);
 	}
+
+	/*
+	* See http://issues.liferay.com/browse/LPS-37502 to see how these values
+	* have been calculated
+	*/
+
+	private static final long _MAX_DELTA = 1600;
+
+	private static final long _MAX_SECURE_DELTA = 2100;
 
 	private static Log _log = LogFactoryUtil.getLog(PwdGeneratorTest.class);
 


### PR DESCRIPTION
Hey Zsolt,

After reviewing your changes with @juliocamarero, we think it'd be simplier to optionally pass the portletPreferences parameter to the prepareManifestSummary method. Only the portlets exporting data based on their preferences would use this parameter. The reported bug affects not only to Web Content Display and Wiki Display, but also to RSS portlet (where you can select one header and one footer Web contents) and to the Polls Display portlet.

I've applied our changes to the JournalContentPortletDataHandler and to the JSPs (export and also publish portlet). Could you please validate and apply this pattern to the PDHs of the rest of the above mentioned portlets?

Thanks!
